### PR TITLE
Add PNG output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project provides a simple tool to evaluate image sensor flare from a 512x51
 2. Run the evaluator:
 
 ```bash
-python flare_evaluator.py your_data.csv --signal-threshold 10 --light-threshold 200 --pixel-size 1.0 --light-amount 100 --plot result.pgm
+python flare_evaluator.py your_data.csv --signal-threshold 10 --light-threshold 200 --pixel-size 1.0 --light-amount 100 --plot result.png
 ```
 
 ### Parameters
@@ -17,6 +17,6 @@ python flare_evaluator.py your_data.csv --signal-threshold 10 --light-threshold 
 - `light-threshold`: Pixel values above this are treated as light source and excluded (default: 250)
 - `pixel-size`: Physical size of one pixel (default: 1.0)
 - `light-amount`: Amount of light for normalization (default: 1.0)
-- `plot`: Output PGM file showing the 2D target region
+- `plot`: Output image (PNG or PGM) showing the 2D target region
 
 The script prints the sum of target pixel values, the number of signal pixels, and the final flare value.

--- a/flare_evaluator.py
+++ b/flare_evaluator.py
@@ -1,5 +1,7 @@
 import csv
 import argparse
+import struct
+import zlib
 from typing import List, Tuple
 
 
@@ -37,15 +39,33 @@ def compute_flare(
         flare_value = sigma_value / (signal_pixel_number * pixel_area) * light_amount
     return flare_value, sigma_value, signal_pixel_number, target_mask
 
-def save_mask_as_pgm(mask: List[List[int]], path: str) -> None:
+def save_mask(mask: List[List[int]], path: str) -> None:
+    """Save mask as a PNG or PGM image based on file extension."""
     height = len(mask)
     width = len(mask[0]) if height else 0
-    with open(path, 'w') as f:
-        f.write('P2\n')
-        f.write(f'{width} {height}\n')
-        f.write('255\n')
-        for row in mask:
-            f.write(' '.join(str(v) for v in row) + '\n')
+
+    if path.lower().endswith('.png'):
+        # Encode as an 8-bit grayscale PNG without external dependencies.
+        raw = b''.join(b'\x00' + bytes(row) for row in mask)
+        compressed = zlib.compress(raw)
+
+        def chunk(tag: bytes, data: bytes) -> bytes:
+            length = struct.pack('>I', len(data))
+            crc = zlib.crc32(tag)
+            crc = zlib.crc32(data, crc)
+            return length + tag + data + struct.pack('>I', crc)
+
+        ihdr = struct.pack('>IIBBBBB', width, height, 8, 0, 0, 0, 0)
+        png = [b'\x89PNG\r\n\x1a\n', chunk(b'IHDR', ihdr), chunk(b'IDAT', compressed), chunk(b'IEND', b'')]
+        with open(path, 'wb') as f:
+            f.writelines(png)
+    else:
+        with open(path, 'w') as f:
+            f.write('P2\n')
+            f.write(f'{width} {height}\n')
+            f.write('255\n')
+            for row in mask:
+                f.write(' '.join(str(v) for v in row) + '\n')
 
 def main() -> None:
     parser = argparse.ArgumentParser(description='Compute flare metric from sensor data CSV.')
@@ -55,7 +75,7 @@ def main() -> None:
     parser.add_argument('--light-threshold', type=float, default=250, help='Pixel value threshold to exclude light source')
     parser.add_argument('--pixel-size', type=float, default=1.0, help='Pixel size for area calculation')
     parser.add_argument('--light-amount', type=float, default=1.0, help='Amount of light used for normalization')
-    parser.add_argument('--plot', type=str, default='target_region.pgm', help='Path to save PGM plot of target region')
+    parser.add_argument('--plot', type=str, default='target_region.png', help='Path to save image of target region (PNG or PGM)')
     args = parser.parse_args()
 
     data = read_csv(args.csv_path)
@@ -67,7 +87,7 @@ def main() -> None:
         pixel_size=args.pixel_size,
         light_amount=args.light_amount,
     )
-    save_mask_as_pgm(mask, args.plot)
+    save_mask(mask, args.plot)
 
     print(f'Sum of target pixel values: {sigma}')
     print(f'Signal pixel number: {num}')


### PR DESCRIPTION
## Summary
- Support saving target mask as either PNG or PGM without external dependencies
- Default output to `target_region.png` and document PNG/PGM usage
- Remove generated PNG artifact from repository

## Testing
- `python flare_evaluator.py sample_data.csv --plot target_region.png`
- `python - <<'PY'
import struct
with open('target_region.png','rb') as f:
 sig=f.read(8)
 length=struct.unpack('>I',f.read(4))[0]
 chunk_type=f.read(4)
 data=f.read(length)
 f.read(4)
 width,height,bit_depth,color_type,comp,filt,inter=struct.unpack('>IIBBBBB',data)
 print('signature',sig)
 print('size',width,height)
 print('bit_depth',bit_depth,'color_type',color_type)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b3f2ee99548326929f8b7b13ed2e08