### PR TITLE
Improve RGB visualization and add bulk CSV processor

### DIFF
--- a/bulk_process.py
+++ b/bulk_process.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Bulk processing utility for Flare Evaluation System.
+
+Iterates through all CSV files in a directory and evaluates each using the
+current CONFIG settings. Results are written to the output directory with the
+same base filename as the input.
+"""
+
+from pathlib import Path
+import argparse
+
+from config import CONFIG
+from flare import process_grayscale, process_rgb
+
+def bulk_process(input_dir: Path, output_dir: Path) -> None:
+    mode = CONFIG.get('mode', 'grayscale')
+    input_dir = Path(input_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for csv_file in sorted(input_dir.glob('*.csv')):
+        stem = csv_file.stem
+        json_path = output_dir / f"{stem}.json"
+        png_path = output_dir / f"{stem}.png"
+        print(f"\n=== Processing {csv_file} ===")
+        if mode == 'rgb':
+            process_rgb(csv_file, output_json=json_path, output_image=png_path)
+        else:
+            process_grayscale(csv_file, output_json=json_path, output_image=png_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bulk process CSV files for flare evaluation")
+    parser.add_argument('input_dir', nargs='?', default='data', help='Directory containing CSV files')
+    parser.add_argument('output_dir', nargs='?', default='output', help='Directory to save outputs')
+    args = parser.parse_args()
+
+    bulk_process(Path(args.input_dir), Path(args.output_dir))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Allow process functions to accept custom output paths
- Color-code RGB visualization so flares, direct light, and light sources are visible
- Add `bulk_process.py` script to evaluate all CSV files in a directory

## Testing
- `python tests/verify_spacing.py`
- `python flare.py`
- `python - <<'PY' from flare import process_rgb
process_rgb('tests/test_rgb.csv', output_json='output/test_rgb.json', output_image='output/test_rgb.png')
PY`
- `python bulk_process.py`

------
https://chatgpt.com/codex/tasks/task_e_68b902ed46f883269a6f55894fc576ad